### PR TITLE
Reset does not work

### DIFF
--- a/functions/wpt_transient.php
+++ b/functions/wpt_transient.php
@@ -20,7 +20,7 @@
 			if ( is_user_logged_in() ) {
 				return false;
 			}
-			$key = 'wpt'.$name.md5(serialize($args));
+			$key = 'wpt_'.$name.md5(serialize($args));
 			return get_transient($key);
 		}
 		
@@ -46,7 +46,7 @@
 		}
 
 		function set($name, $args, $value) {
-			$key = 'wpt'.$name.md5(serialize($args));
+			$key = 'wpt_'.$name.md5(serialize($args));
 			set_transient($key, $value, 10 * MINUTE_IN_SECONDS );
 		}
 		


### PR DESCRIPTION
Transient key prefix does not end with _

Alternative is to modify the delete query (`"DELETE FROM $wpdb->options WHERE option_name LIKE '\_transient\_wpt%'"`) but I thought adding the prefix was "better".