### PR TITLE
Prevent save event loop

### DIFF
--- a/functions/wpt_event_admin.php
+++ b/functions/wpt_event_admin.php
@@ -249,6 +249,10 @@ class WPT_Event_Admin {
 			return $post_id;
 		}
 
+		if ( WPT_Event::post_type_name != get_post_type( $production_id )) {
+			return $post_id;
+		}
+
 		// Unhook to avoid loops and make sure it only runs once.
 		remove_action( 'save_post', array( $this, 'save_event' ) );
 

--- a/functions/wpt_event_admin.php
+++ b/functions/wpt_event_admin.php
@@ -253,17 +253,11 @@ class WPT_Event_Admin {
 			return $post_id;
 		}
 
-		// Unhook to avoid loops and make sure it only runs once.
-		remove_action( 'save_post', array( $this, 'save_event' ) );
-
 		/* OK, its safe for us to save the data now. */
 
 		foreach ($wp_theatre->event_editor->get_fields( $post_id ) as $field) {
 			$wp_theatre->event_editor->save_field($field, $post_id, $_POST);
 		}
-			
-		// Re-hook.
-		add_action( 'save_post', array( $this, 'save_event' ) );
 	}
 	
 }

--- a/functions/wpt_event_admin.php
+++ b/functions/wpt_event_admin.php
@@ -249,7 +249,7 @@ class WPT_Event_Admin {
 			return $post_id;
 		}
 
-		if ( WPT_Event::post_type_name != get_post_type( $production_id )) {
+		if ( WPT_Event::post_type_name != get_post_type( $post_id )) {
 			return $post_id;
 		}
 

--- a/functions/wpt_event_admin.php
+++ b/functions/wpt_event_admin.php
@@ -240,7 +240,7 @@ class WPT_Event_Admin {
 			return $post_id;
 
 		// If this is an autosave, our form has not been submitted,
-        //     so we don't want to do anything.
+		// so we don't want to do anything.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) 
 			return $post_id;
 

--- a/functions/wpt_event_admin.php
+++ b/functions/wpt_event_admin.php
@@ -249,12 +249,17 @@ class WPT_Event_Admin {
 			return $post_id;
 		}
 
+		// Unhook to avoid loops and make sure it only runs once.
+		remove_action( 'save_post', array( $this, 'save_event' ) );
+
 		/* OK, its safe for us to save the data now. */
 
 		foreach ($wp_theatre->event_editor->get_fields( $post_id ) as $field) {
 			$wp_theatre->event_editor->save_field($field, $post_id, $_POST);
 		}
 			
+		// Re-hook.
+		add_action( 'save_post', array( $this, 'save_event' ) );
 	}
 	
 }


### PR DESCRIPTION
Just as done in `WPT_Event_Editor::save_event` the `save_post` action must be temporarily disabled here.