### PR TITLE
Use correct translation for admin menus

### DIFF
--- a/functions/wpt_admin.php
+++ b/functions/wpt_admin.php
@@ -173,8 +173,8 @@ class WPT_Admin {
 	 */
 	function add_theater_menu() {
 		add_menu_page( 
-			__('Theater','wp_theatre'), 
-			__('Theater','wp_theatre'), 
+			__('Theater','theatre'), 
+			__('Theater','theatre'), 
 			'edit_posts', 
 			'theater-events', 
 			array(), 
@@ -192,7 +192,7 @@ class WPT_Admin {
 	function add_settings_menu() {
 		add_submenu_page( 
 			'theater-events',
-			__('Theater','wp_theatre').' '.__('Settings'), 
+			__('Theater','theatre').' '.__('Settings'), 
 			__('Settings'), 
 			'manage_options', 
 			'wpt_admin', 


### PR DESCRIPTION
Hi,

I noticed that the "Theater" menu in the admin dashboard was not being translated when the plugin was activated.

I tacked this down to an incorrect wp_theatre domain when setting up the admin menu, it should have been just theatre.

Thanks,

Tom