### PR TITLE
Fix for images overlapping on Extensions page

### DIFF
--- a/functions/extensions/wpt_extensions_promo.php
+++ b/functions/extensions/wpt_extensions_promo.php
@@ -11,6 +11,9 @@ class WPT_Extensions_Promo {
 		
 		// Add the 'extensions' submenu with priority 40 to move it below the 'settings' submenu.
 		add_action( 'admin_menu', array( $this, 'add_menu' ), 40 );
+
+		// Add hard-coded CSS class until WP issue 18857 fixed
+		add_filter( 'admin_body_class', array( $this, 'add_admin_body_class'));
 	}
 
 	/**
@@ -54,6 +57,20 @@ class WPT_Extensions_Promo {
 		$links[] = '<a href="' . esc_url( $extensions_link ) . '">' . esc_html__( 'Extensions', 'theatre' ) . '</a>';
 
 		return $links;
+	}
+
+	/**
+	 * Adds a hard-coded CSS class to the admin body tag, workaround for WP issue 18857.
+	 *
+	 * @since	0.XXX
+	 * @param	string	$classes	A space-separated string of CSS class names.
+	 * @return	string	A space-separated string of CSS class names with dditional classes added.
+	 */
+	function add_admin_body_class($classes) {
+
+		$classes .= " theater_page_wpt_extensions";
+
+		return $classes;
 	}
 
 	/**

--- a/functions/wpt_admin.php
+++ b/functions/wpt_admin.php
@@ -173,8 +173,8 @@ class WPT_Admin {
 	 */
 	function add_theater_menu() {
 		add_menu_page( 
-			__('Theater','theatre'), 
-			__('Theater','theatre'), 
+			__('Theater','wp_theatre'), 
+			__('Theater','wp_theatre'), 
 			'edit_posts', 
 			'theater-events', 
 			array(), 
@@ -192,7 +192,7 @@ class WPT_Admin {
 	function add_settings_menu() {
 		add_submenu_page( 
 			'theater-events',
-			__('Theater','theatre').' '.__('Settings'), 
+			__('Theater','wp_theatre').' '.__('Settings'), 
 			__('Settings'), 
 			'manage_options', 
 			'wpt_admin', 

--- a/functions/wpt_admin.php
+++ b/functions/wpt_admin.php
@@ -173,8 +173,8 @@ class WPT_Admin {
 	 */
 	function add_theater_menu() {
 		add_menu_page( 
-			__('Theater','wp_theatre'), 
-			__('Theater','wp_theatre'), 
+			__('Theater','theatre'), 
+			__('Theater','theatre'), 
 			'edit_posts', 
 			'theater-events', 
 			array(), 
@@ -192,7 +192,7 @@ class WPT_Admin {
 	function add_settings_menu() {
 		add_submenu_page( 
 			'theater-events',
-			__('Theater','wp_theatre').' '.__('Settings'), 
+			__('Theater','theatre').' '.__('Settings'), 
 			__('Settings'), 
 			'manage_options', 
 			'wpt_admin', 


### PR DESCRIPTION
When the plugin is translated (specifically the 'Theater' key) this causes an issue where the Images on the Extensions admin page overlap the text.

The body CSS class when using en_US language includes theater_page_wpt_extensions but in en_GB it is theatre_page_wpt_extensions.

This is caused by WordPress issue [18857](https://core.trac.wordpress.org/ticket/18857) as it uses the title passed to add_menu_page().

I've just added a hard-coded CSS class to match that used in the admin.css.

This issue is masked by [PR 301](https://github.com/slimndap/wp-theatre/pull/301) so won't show up until that is applied.