### PR TITLE
cleanup transients in option THEATER_TRANSIENTS_OPTION

### DIFF
--- a/functions/transient/class-theater-transient.php
+++ b/functions/transient/class-theater-transient.php
@@ -206,9 +206,7 @@ class Theater_Transient {
 
 		$result = delete_transient( $this->key );
 
-		if ( $result ) {
-			$this->unregister();
-		}
+		$this->unregister();
 
 		return $result;
 	}


### PR DESCRIPTION
Fix to: remove nonexisting transients from transient list (option THEATER_TRANSIENTS_OPTION).

Steps to reproduce:
* open Kalendar, some Productions and/or Events in Frontend
* check existing transients
  - wp option get theater_transient_keys
  - wp transient get 'one from list above'
* wait more than 10 minutes
* open wp-admin, open some production
* check transients again (see above)
  - current result: transients exist in option theater_transient_keys, transients are empty
  - expected: option theater_transient_keys should be empty

For long running sites this leads to a huge amount of entries in option theater_transient_keys.
Each of them is reset again and again on many actions in wp-admin.
This leads to really slow backend pages.

About the change:
wordpress delete_transient() returns false if transient does not exist (anymore).
This is not an error condition. So removing the transient key from theater_transient_keys should always happen.